### PR TITLE
Add a check to solve flickering issues

### DIFF
--- a/core/java/android/hardware/fingerprint/FingerprintManager.java
+++ b/core/java/android/hardware/fingerprint/FingerprintManager.java
@@ -1046,7 +1046,10 @@ public class FingerprintManager implements BiometricAuthenticator, BiometricFing
      */
     public boolean isPowerbuttonFps() {
         final FingerprintSensorPropertiesInternal sensorProps = getFirstFingerprintSensor();
-        return sensorProps.sensorType == TYPE_POWER_BUTTON;
+         if (sensorProps != null) {
+            return sensorProps.sensorType == TYPE_POWER_BUTTON;
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
In some cases, senorProps can be null. This may cause screen flickering issues in the rom.
Add a conditional check to get around this.